### PR TITLE
Make sure hamburger menu is accessible by keyboard navigation

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -5,7 +5,7 @@
 <input type="checkbox" class="sidebar-checkbox" id="sidebar-checkbox">
 
 <!-- Toggleable sidebar -->
-<aside class="sidebar" id="sidebar">
+<aside class="sidebar" id="sidebar" aria-hidden="true">
   <div class="sidebar-item">
     <p>{{ site.description }}</p>
   </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,14 +24,13 @@
             <br><small>{{ site.tagline }}</small>
           </h3>
         </div>
+        <button class="sidebar-toggle" aria-label="Open navigation menu" aria-expanded="false"></button>
       </header>
 
       <main class="container content" id="main">
         {{ content }}
       </main>
     </div>
-
-    <label for="sidebar-checkbox" class="sidebar-toggle"></label>
 
     <script>
 
@@ -49,21 +48,23 @@
         document.getElementById("main").innerHTML = content.replace(regex, "<mark>$1</mark>");
       }
 
-      // Toggle sidebar
+      // Support sidebar toggle
       (function(document) {
         var toggle = document.querySelector('.sidebar-toggle');
         var sidebar = document.querySelector('#sidebar');
+        var sidebarNavLink = document.querySelector('.sidebar-nav-item');
         var checkbox = document.querySelector('#sidebar-checkbox');
 
-        document.addEventListener('click', function(e) {
-          var target = e.target;
+        // Make sure we focus on the menu once it opens to aid tab navigation
+        sidebar.addEventListener('transitionend', () => {sidebarNavLink.focus()});
 
-          if(!checkbox.checked ||
-             !sidebar.contains(target) ||
-             (target === checkbox || target === toggle)) return;
+        // Toggle sidebar
+        toggle.addEventListener('click', function(e) {
+          e.preventDefault();
 
-          checkbox.checked = false;
-        }, false);
+          checkbox.checked = !checkbox.checked;
+          toggle.setAttribute('aria-expanded', checkbox.checked);
+        });
       })(document);
     </script>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,6 +17,11 @@
       collisions with our real content.
     -->
     <div class="wrap">
+      <button class="sidebar-toggle"
+          aria-label="Open navigation menu"
+          aria-expanded="false"
+          aria-controls="sidebar">
+      </button>
       <header class="masthead">
         <div class="container">
           <h3 class="masthead-title">
@@ -24,7 +29,6 @@
             <br><small>{{ site.tagline }}</small>
           </h3>
         </div>
-        <button class="sidebar-toggle" aria-label="Open navigation menu" aria-expanded="false"></button>
       </header>
 
       <main class="container content" id="main">
@@ -55,16 +59,25 @@
         var sidebarNavLink = document.querySelector('.sidebar-nav-item');
         var checkbox = document.querySelector('#sidebar-checkbox');
 
-        // Make sure we focus on the menu once it opens to aid tab navigation
-        sidebar.addEventListener('transitionend', () => {sidebarNavLink.focus()});
-
         // Toggle sidebar
         toggle.addEventListener('click', function(e) {
           e.preventDefault();
 
           checkbox.checked = !checkbox.checked;
           toggle.setAttribute('aria-expanded', checkbox.checked);
+          sidebar.setAttribute('aria-hidden', !checkbox.checked);
         });
+
+        // Make sure we focus on the menu once it opens to aid tab navigation
+        sidebar.addEventListener('transitionend', function() {sidebarNavLink.focus()});
+
+        // Clicking anywhere in the sidebar should close the menu
+        sidebar.addEventListener('click', function(e) {
+          checkbox.checked = false;
+          toggle.setAttribute('aria-expanded', false);
+          sidebar.setAttribute('aria-hidden', true);
+        })
+
       })(document);
     </script>
 

--- a/_sass/_ed.scss
+++ b/_sass/_ed.scss
@@ -409,10 +409,11 @@ a.sidebar-nav-item:focus {
   top:  .8rem;
   left: 1rem;
   display: block;
-  padding: .25rem .75rem;
+  padding: .5rem .75rem;
   color: #505050;
   background-color: #fff;
   border-radius: .25rem;
+  border: none;
   cursor: pointer;
 }
 

--- a/_sass/_ed.scss
+++ b/_sass/_ed.scss
@@ -428,6 +428,10 @@ a.sidebar-nav-item:focus {
   background-image:         linear-gradient(to bottom, #555, #555 20%, #fff 20%, #fff 40%, #555 40%, #555 60%, #fff 60%, #fff 80%, #555 80%, #555 100%);
 }
 
+.sidebar-toggle:focus {
+  border: solid #555 1px;
+}
+
 .sidebar-toggle:active,
 #sidebar-checkbox:focus ~ .sidebar-toggle,
 #sidebar-checkbox:checked ~ .sidebar-toggle {


### PR DESCRIPTION
Hello! Thank you for making such a lovely, clean looking theme.

I am currently using Ed for my blog and noticed that I could make some improvements to the accessibility of its hamburger menu. With the current version, you can't navigate to the menu using the keyboard. If you're not familiar with this idea, I'm using [tab navigation](https://en.wikipedia.org/wiki/Tabbing_navigation) and based my changes on [these sorts of guidelines](https://webaim.org/techniques/keyboard/).

Proposed changes in this PR:
- Replace the menu `label` element with a `button`
- Add ARIA attributes to the menu button to support screen readers (ie `aria-label` and `aria-expanded`)
- Move the focus to the first link in the sidebar menu once it has finished sliding out (on `transitionend`).

I also simplified the sidebar toggle JavaScript by a fair amount, so please let me know if I missed something in those changes. My goal was to make sure the theme still looked and behaved the same while allowing for tabbing to the menu. You can see these changes in effect on my blog:

https://blog.katiebroida.com/

Chrome has the most obvious focus highlighting out of the box, so you may want to tab through it in Chrome. 

Thanks again for this theme! Looking forward to your thoughts on this. 