### PR TITLE
Bump TravisCI Ruby version to 2.2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.2.2
+- 2.2.7
 
 
 # Assume bundler is being used, therefore


### PR DESCRIPTION
New builds are failing because the `listen` 3.2.0 dependency for
`jekyll-watch` 2.0.0 requires Ruby >= 2.2.7

If this fixes the build, I'll need to update the required Ruby
version in the gemspec to 2.2.7.