### PR TITLE
Adjust vertical alignment of hamburger icon

### DIFF
--- a/_sass/_ed.scss
+++ b/_sass/_ed.scss
@@ -374,6 +374,7 @@ a.sidebar-nav-item:focus {
 
 .sidebar-toggle:before {
   display: inline-block;
+  vertical-align: middle;
   width: 1rem;
   height: .75rem;
   content: "";


### PR DESCRIPTION
Sorry to intrude on your theme, but I made this change for my local blog and thought y'all might want to consider it for the main source. Basically, it's just adding vertical alignment to the hamburger icon when the menu is expanded. Right now it looks slightly high.

Before: 
<img width="1082" alt="Screen Shot 2020-12-26 at 4 51 53 PM" src="https://user-images.githubusercontent.com/8980594/103159696-75186200-479a-11eb-9aae-a36976b037b4.png">

After:
<img width="1083" alt="Screen Shot 2020-12-26 at 4 51 44 PM" src="https://user-images.githubusercontent.com/8980594/103159697-777abc00-479a-11eb-9549-622a37892103.png">

Just a 1 line diff. Let me know what your thoughts are. Happy New Year.